### PR TITLE
Fix error about moved value

### DIFF
--- a/content/hexagonal-architecture-in-rust-2.md
+++ b/content/hexagonal-architecture-in-rust-2.md
@@ -41,7 +41,7 @@ fn it_should_return_a_conflict_error_when_pokemon_number_already_exists() {
     let mut repo = InMemoryRepository::new();
     repo.insert(number, name, types);
     let req = Request {
-        number: u16::from(number),
+        number: 25,
         name: String::from("Charmander"),
         types: vec![String::from("Fire")],
     };


### PR DESCRIPTION
In the sample code on Github, this is hardcoded as 25, which compiles.
https://github.com/alexislozano/pokedex/blob/d112b4bae8f5afb5faa01f4624481a2d04a71d71/src/domain/create_pokemon.rs#L42
Exact error message: "use of moved value: `id`"